### PR TITLE
expose transpile_serverside as public

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ typescript = ["swc", "swc_ecma_parser", "swc_common", "swc_ecma_minifier"]
 [dependencies]
 hirofa_utils = "0.7"
 #hirofa_utils = {path="../utils"}
-#hirofa_utils = {git="https://github.com/SreeniIO/utils.git"}
 #hirofa_utils = {git="https://github.com/HiRoFa/utils"}
 backtrace = "0.3.67"
 libquickjs-sys = "0.10.0"

--- a/src/quickjsrealmadapter.rs
+++ b/src/quickjsrealmadapter.rs
@@ -620,7 +620,7 @@ impl QuickJsRealmAdapter {
                     args_fac.push(realm.to_js_value_facade(arg)?);
                 }
                 let fut = js_function(this_fac, args_fac);
-                realm.create_resolving_promise_async(async move { fut.await }, |realm, pres| {
+                realm.create_resolving_promise_async(fut, |realm, pres| {
                     //
                     realm.from_js_value_facade(pres)
                 })

--- a/src/quickjsruntimeadapter.rs
+++ b/src/quickjsruntimeadapter.rs
@@ -385,7 +385,7 @@ impl QuickJsRuntimeAdapter {
                 pp.process(&mut script)?;
             }
             #[cfg(feature = "typescript")]
-            crate::typescript::transpile_serverside(q_js_rt, &mut script)?;
+            crate::typescript::transpile_serverside(&mut script)?;
 
             // todo see if script has a map, store that map
             Ok(script)

--- a/src/typescript/mod.rs
+++ b/src/typescript/mod.rs
@@ -225,8 +225,7 @@ thread_local! {
 }
 
 // fix stacktrace method
-pub(crate) fn transpile_serverside(
-    _rt: &QuickJsRuntimeAdapter,
+pub fn transpile_serverside(
     script: &mut Script,
 ) -> Result<(), JsError> {
     // transpile and store map in qjsrt


### PR DESCRIPTION
Also removed the unused QuickJsRuntimeAdapter arg.

This change would allow reusing the transpile_serverside function inside CompiledModuleLoader without having to re-implement the same functionality downstream.